### PR TITLE
Quote file paths in ffmpeg commands

### DIFF
--- a/backgroundremover/utilities.py
+++ b/backgroundremover/utilities.py
@@ -184,7 +184,7 @@ def transparentgif(output, file_path,
               frame_limit,
               prefetched_batches,
               framerate)
-    cmd = "nice -10 ffmpeg -y -i %s -i %s -filter_complex '[1][0]scale2ref[mask][main];[main][mask]alphamerge=shortest=1,fps=10,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse' -shortest %s" % (
+    cmd = "nice -10 ffmpeg -y -i '%s' -i '%s' -filter_complex '[1][0]scale2ref[mask][main];[main][mask]alphamerge=shortest=1,fps=10,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse' -shortest '%s'" % (
         file_path, temp_file, output)
     sp.run(shlex.split(cmd))
     print("Process finished")
@@ -210,7 +210,7 @@ def transparentgifwithbackground(output, overlay, file_path,
               prefetched_batches,
               framerate)
     print("Starting alphamerge")
-    cmd = "nice -10 ffmpeg -y -i %s -i %s -i %s -filter_complex '[1][0]scale2ref[mask][main];[main][mask]alphamerge=shortest=1[fg];[2][fg]overlay=(main_w-overlay_w)/2:(main_h-overlay_h)/2:format=auto,fps=10,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse' -shortest %s" % (
+    cmd = "nice -10 ffmpeg -y -i '%s' -i '%s' -i '%s' -filter_complex '[1][0]scale2ref[mask][main];[main][mask]alphamerge=shortest=1[fg];[2][fg]overlay=(main_w-overlay_w)/2:(main_h-overlay_h)/2:format=auto,fps=10,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse' -shortest '%s'" % (
         file_path, temp_file, overlay, output)
     sp.run(shlex.split(cmd))
     print("Process finished")
@@ -239,7 +239,7 @@ def transparentvideo(output, file_path,
               prefetched_batches,
               framerate)
     print("Starting alphamerge")
-    cmd = "nice -10 ffmpeg -y -nostats -loglevel 0 -i %s -i %s -filter_complex '[1][0]scale2ref[mask][main];[main][mask]alphamerge=shortest=1' -c:v qtrle -shortest %s" % (
+    cmd = "nice -10 ffmpeg -y -nostats -loglevel 0 -i '%s' -i '%s' -filter_complex '[1][0]scale2ref[mask][main];[main][mask]alphamerge=shortest=1' -c:v qtrle -shortest '%s'" % (
         file_path, temp_file, output)
     process = sp.Popen(cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
     stdout, stderr = process.communicate()
@@ -273,7 +273,7 @@ def transparentvideoovervideo(output, overlay, file_path,
               prefetched_batches,
               framerate)
     print("Starting alphamerge")
-    cmd = "nice -10 ffmpeg -y -i %s -i %s -i %s -filter_complex '[1][0]scale2ref[mask][main];[main][mask]alphamerge=shortest=1[vid];[vid][2:v]scale2ref[fg][bg];[bg][fg]overlay=shortest=1[out]' -map [out] -shortest %s" % (
+    cmd = "nice -10 ffmpeg -y -i '%s' -i '%s' -i '%s' -filter_complex '[1][0]scale2ref[mask][main];[main][mask]alphamerge=shortest=1[vid];[vid][2:v]scale2ref[fg][bg];[bg][fg]overlay=shortest=1[out]' -map [out] -shortest '%s'" % (
         file_path, temp_file, overlay, output)
     sp.run(shlex.split(cmd))
     print("Process finished")
@@ -303,11 +303,11 @@ def transparentvideooverimage(output, overlay, file_path,
               framerate)
     print("Scale image")
     temp_image = os.path.abspath("%s/new.jpg" % tmpdirname)
-    cmd = "nice -10 ffmpeg -i %s -i %s -filter_complex 'scale2ref[img][vid];[img]setsar=1;[vid]nullsink' -q:v 2 %s" % (
+    cmd = "nice -10 ffmpeg -i '%s' -i '%s' -filter_complex 'scale2ref[img][vid];[img]setsar=1;[vid]nullsink' -q:v 2 '%s'" % (
         overlay, file_path, temp_image)
     sp.run(shlex.split(cmd))
     print("Starting alphamerge")
-    cmd = "nice -10 ffmpeg -y -i %s -i %s -i %s -filter_complex '[0:v]scale2ref=oh*mdar:ih[bg];[1:v]scale2ref=oh*mdar:ih[fg];[bg][fg]overlay=(W-w)/2:(H-h)/2:shortest=1[out]' -map [out] -shortest %s" % (
+    cmd = "nice -10 ffmpeg -y -i '%s' -i '%s' -i '%s' -filter_complex '[0:v]scale2ref=oh*mdar:ih[bg];[1:v]scale2ref=oh*mdar:ih[fg];[bg][fg]overlay=(W-w)/2:(H-h)/2:shortest=1[out]' -map [out] -shortest '%s'" % (
         temp_image, file_path, temp_file, output)
     sp.run(shlex.split(cmd))
     print("Process finished")


### PR DESCRIPTION
Files with unusual characters in them, such as parentheses, would cause the alphamerge commands to fail. Quoting these parameters avoids that (as long as the unusual character isn't a single quote, that's still an issue with or without this change).