### PR TITLE
Add logging to replace print satement for debugging

### DIFF
--- a/backgroundremover/u2net/detect.py
+++ b/backgroundremover/u2net/detect.py
@@ -3,12 +3,22 @@ import os
 import sys
 import numpy as np
 import torch
+import logging
 from hsh.library.hash import Hasher
 from PIL import Image
 from torchvision import transforms
 
 from . import data_loader, u2net
 from .. import github
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+logger.propagate = False
+
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter('%(levelname)s - %(message)s'))
+    logger.addHandler(handler)
 
 
 def load_model(model_name: str = "u2net"):
@@ -50,7 +60,7 @@ def load_model(model_name: str = "u2net"):
             os.path.expanduser(os.path.join("~", ".u2net", model_name + ".pth")),
         )
 
-        print(f"DEBUG: path to be checked: {path}")
+        logger.debug(f"path to be checked: {path}")
 
         if (
             not os.path.exists(path)


### PR DESCRIPTION
Replaces the hardcoded print statement used for debugging with a configurable logging setup. Specifically:

Replaces `print(f"DEBUG: path to be checked: {path}")` with `logger.debug(f"path to be checked: {path}")`.
Introduces a module-level logger that doesn't propagate, to avoid affecting other parts of the library or user's project.
Maintains the same output format for consistency.
Allows users to easily enable or disable debug output without modifying the source code.

This change improves flexibility for debugging while maintaining the existing functionality.