### PR TITLE
:bug: Fix issue with framerate count

### DIFF
--- a/backgroundremover/utilities.py
+++ b/backgroundremover/utilities.py
@@ -89,7 +89,8 @@ def matte_key(output, file_path,
         file_path
     ]
     framerate_output = sp.check_output(cmd, universal_newlines=True)
-    total_frames = int(framerate_output)
+    framerate_output_clean = framerate_output.strip().strip(',')
+    total_frames = int(framerate_output_clean)
     if frame_limit != -1:
         total_frames = min(frame_limit, total_frames)
 


### PR DESCRIPTION
framerate_count is in the regex form '\d+,\n', which when the function int(<input>) is called with it, fails. To solve this, I strip both the '\n' and ',' by calling .strip().strip(',') on that output to result in '\d+' which when int(<input>) is called with results in no error thrown