### PR TITLE
fix: Pin moviepy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ pymatting>=1.1.1
 filetype>=1.0.7
 hsh>=1.1.0
 more_itertools>=8.7.0
-moviepy>=1.0.3
+moviepy==1.0.3
 Pillow>=8.1.1,<10.0.0
 ffmpeg-python


### PR DESCRIPTION
In order to prevent breaking backgroundremover, it is necessary to temporarily pin the version of moviepy to 1.0.3. The latest version which released recently (2.0.0) introduces changes which currently do not work with backgroundremover when attempting to use it for videos.