### PR TITLE
utilities: replace `numpy.ndarray.tostring` with `numpy.ndarray.tobytes`

### DIFF
--- a/backgroundremover/utilities.py
+++ b/backgroundremover/utilities.py
@@ -153,7 +153,7 @@ def matte_key(output, file_path,
 
                     proc = sp.Popen(command, stdin=sp.PIPE)
 
-                proc.stdin.write(frame.tostring())
+                proc.stdin.write(frame.tobytes())
                 frame_counter = frame_counter + 1
 
                 if frame_counter >= total_frames:


### PR DESCRIPTION
`numpy.ndarray.tostring` has been deprecated since numpy `1.19.0` and has been removed in numpy `2.3` in favour of `numpy.ndarray.tobytes`.

Version 2.2.0: https://numpy.org/doc/2.2/reference/generated/numpy.ndarray.tostring.html
Missing in stable: https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tostring.html