### PR TITLE
cli: allow background image to be optional

### DIFF
--- a/backgroundremover/cmd/cli.py
+++ b/backgroundremover/cmd/cli.py
@@ -173,7 +173,7 @@ def main():
         "-bi",
         "--backgroundimage",
         nargs="?",
-        default="-",
+        default=None,
         type=argparse.FileType("rb"),
         help="Path to background image.",
     )


### PR DESCRIPTION
When no background image is provided via `-bi` or `-backgroundimage`, the CLI currently defaults to stdin. The CLI then gets stuck when no image is piped into the process, see #178 
The expected behavior is defaulting to transparency as the background, when no flag set.
This PR changes the default background to transparency